### PR TITLE
Add param & code to __init__ to enable Always on Top

### DIFF
--- a/CTkToolTip/ctk_tooltip.py
+++ b/CTkToolTip/ctk_tooltip.py
@@ -8,7 +8,6 @@ import sys
 import customtkinter
 from tkinter import Toplevel, Frame
 
-
 class CTkToolTip(Toplevel):
     """
     Creates a ToolTip (pop-up) widget for customtkinter.
@@ -28,6 +27,7 @@ class CTkToolTip(Toplevel):
             border_color: str = None,
             alpha: float = 0.95,
             padding: tuple = (10, 2),
+            always_on_top: bool = False,
             **message_kwargs):
 
         super().__init__()
@@ -57,6 +57,9 @@ class CTkToolTip(Toplevel):
 
         # Make the background transparent
         self.config(background=self.transparent_color)
+
+        if always_on_top:
+            self.attributes("-topmost", True)
 
         # StringVar instance for msg string
         self.messageVar = customtkinter.StringVar()


### PR DESCRIPTION
Hello, I would like to submit a PR to add a new input parameter to the `__init__` function of the `CTkToolTip` class: `always_on_top`. 

When `always_on_top` is set to True, then the tooltip widget will be created with the [`--topmost` attribute](https://wiki.tcl-lang.org/page/always+on+top) set to `True`. This is helpful for implementing this widget into GUI environments where there are Z-stack order conflicts. 

For example, you might find that using this widget out-of-the-box results in tooltips appearing behind the calling window. Here's an example below, from where I have the mouse hovering over a nearby button on a pop-up window:


<img width="164" height="171" alt="image" src="https://github.com/user-attachments/assets/3f427759-2eb8-4c07-a51c-bb2c1a64f86c" />


Adding the `--topmost` attribute to the tooltip widget resolves this issue, and it would be useful to have this available.