### PR TITLE
Added (un)block_update_dimensions_event handling function.

### DIFF
--- a/CTkToolTip/ctk_tooltip.py
+++ b/CTkToolTip/ctk_tooltip.py
@@ -253,6 +253,12 @@ class CTkToolTip(Toplevel):
         self.messageVar.set(message)
         self.message_label.configure(**kwargs)
 
+    def block_update_dimensions_event(self) -> True:
+        return True
+
+    def unblock_update_dimensions_event(self) -> True:
+        return True
+
     def destroy(self) -> None:
         """
         Destroy the tooltip and clean up bindings.


### PR DESCRIPTION
Hello, I would like to contribute a code update to handle Tkinter resolution scaling events that are sent to this widget. When a GUI widget is ran in a desktop environment that has a scaled resolution (say you're using a laptop with a 4K display but it is scaled 150% via Windows resolution settings), Tkinter will handle scale-up events for widgets by sending a block_update_dimensions_event. This event is handled at the CTk level, but needs to be addressed at this widget level to prevent the widget from breaking due to this event being unhandled. 

When unhandled, the CTkToolTip widget can enter into a state that where the alpha-transparency of the widget is broken, leaving tooltips very transparent regardless of the alpha setting set for the widget. By handling these events, we can ensure that this adverse behavior does not happen. So, I am proposing we add code to CTkToolTip that handles these events by simply returning `True`, which will preserve existing tooltip behavior and ensure the alpha-transparency of widgets does not break on scaled-up resolution displays. 

Attached are pictures showing examples of broken behavior caused by not handling this event:

**Example traceback from event being unhandled:**
<img width="1570" height="257" alt="image" src="https://github.com/user-attachments/assets/51883069-abd3-4045-a2f1-9af2e31dd563" />

**Example impact to CTkToolTip widget when event is unhandled:**
<img width="424" height="204" alt="button_scaling_impact" src="https://github.com/user-attachments/assets/5a14b6e9-3263-47b3-bad8-8ea8502ba10c" />

**Example of widget functioning with new code, when the window rides between a scaled display and an unscaled display (this situation will always trigger the event in question):**
<img width="1052" height="775" alt="Screenshot 2026-03-30 113724" src="https://github.com/user-attachments/assets/67bbf059-808a-4cb8-8600-e5f0d3da1ae3" />
